### PR TITLE
OP-47: Adding the custom_form feature

### DIFF
--- a/modules/custom/custom_form/custom_form.info.yml
+++ b/modules/custom/custom_form/custom_form.info.yml
@@ -1,0 +1,4 @@
+name: Custom Form
+description: Gets user details & enforce the submit rules
+type: module
+core_version_requirement: ^9 | ^10

--- a/modules/custom/custom_form/custom_form.install
+++ b/modules/custom/custom_form/custom_form.install
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Implement hook_schema().
+ * Giving the details of the schema so that it can be stored correspondingly in database
+ */
+
+function custom_form_schema() {
+    $schema['user_details'] = [
+        'description' => 'Contains User details',
+        'fields' => [
+            'id' => [
+                'description' => 'Holds the Id',
+                'type' => 'serial',
+                'not null' => true,
+                'unsigned' => true,
+            ],
+            'name' => [
+                'description' => 'Username',
+                'type' => 'varchar',
+                'length' => 50,
+                'not null' => true,
+            ],
+            'mail' => [
+                'description' => 'User Email id',
+                'type' => 'varchar',
+                'length' => 50,
+                'not null' => true,
+            ],
+            'gender' => [
+                'description' => 'User Gender',
+                'type' => 'varchar',
+                'length' => 50,
+                'not null' => true,
+            ],
+        ],
+        'primary key' => ['id'],
+    ];
+    return $schema;
+}

--- a/modules/custom/custom_form/custom_form.libraries.yml
+++ b/modules/custom/custom_form/custom_form.libraries.yml
@@ -1,0 +1,4 @@
+customjsform:
+  version: '1.0'
+  js:
+    js/customform.js: {}

--- a/modules/custom/custom_form/custom_form.routing.yml
+++ b/modules/custom/custom_form/custom_form.routing.yml
@@ -1,0 +1,7 @@
+custom-user-form:
+  path: '/get-user-details'
+  defaults:
+    _form: '\Drupal\custom_form\Form\CustomUserDetails'
+    _title: 'User Details Form'
+  requirements:
+    _permission: 'user details custom form permission'

--- a/modules/custom/custom_form/custom_form.routing.yml
+++ b/modules/custom/custom_form/custom_form.routing.yml
@@ -7,7 +7,7 @@ custom-user-form:
     _permission: 'user details custom form permission'
     # below line will give the access only for authenticated, content_editor & administrator(i.e as administrator)
     # will have the authenticated user access
-    #_role: 'authenticated + content_editor'
+    # _role: 'authenticated + content_editor'
     # below line will give access only to authenticated & content_editor. It doesn't give the access for
     # administrator
-    #_role: 'authenticated + content_editor'
+    # _role: 'authenticated + content_editor'

--- a/modules/custom/custom_form/custom_form.routing.yml
+++ b/modules/custom/custom_form/custom_form.routing.yml
@@ -5,3 +5,9 @@ custom-user-form:
     _title: 'User Details Form'
   requirements:
     _permission: 'user details custom form permission'
+    # below line will give the access only for authenticated, content_editor & administrator(i.e as administrator)
+    # will have the authenticated user access
+    #_role: 'authenticated + content_editor'
+    # below line will give access only to authenticated & content_editor. It doesn't give the access for
+    # administrator
+    #_role: 'authenticated + content_editor'

--- a/modules/custom/custom_form/src/Form/CustomUserDetails.php
+++ b/modules/custom/custom_form/src/Form/CustomUserDetails.php
@@ -18,6 +18,8 @@ class CustomUserDetails extends FormBase {
      * Defining the buildForm() method
      **/
     public function buildForm(array $form, FormStateInterface $form_state) {
+        // Adding the customjsform library to be only applied to this form.
+        $form['#attached']['library'][] = "custom_form/customjsform";
         $form['username'] = [
             '#type' => 'textfield',
             '#title' => 'User Name',

--- a/modules/custom/custom_form/src/Form/CustomUserDetails.php
+++ b/modules/custom/custom_form/src/Form/CustomUserDetails.php
@@ -61,5 +61,12 @@ class CustomUserDetails extends FormBase {
      **/
     public function submitForm(array &$form, FormStateInterface $form_state) {
         \Drupal::messenger()->addMessage("User Details Submitted Successfully");
+        $values = $form_state->getValues();
+        // Pushing the user details into the database & executing it
+        \Drupal::database()->insert('user_details')->fields([
+            'name' => $values['username'],
+            'mail' => $values['usermail'],
+            'gender' => $values['usergender'],
+        ])->execute();
     }
 }

--- a/modules/custom/custom_form/src/Form/CustomUserDetails.php
+++ b/modules/custom/custom_form/src/Form/CustomUserDetails.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\custom_form\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+class CustomUserDetails extends FormBase {
+    /**
+     * {@inheritdoc}
+     **/
+    public function getFormId() {
+        return "custom_user_details_form";
+    }
+
+    /**
+     * {@inheritdoc}
+     * Defining the buildForm() method
+     **/
+    public function buildForm(array $form, FormStateInterface $form_state) {
+        $form['username'] = [
+            '#type' => 'textfield',
+            '#title' => 'User Name',
+            '#required' => true,
+        ];
+        $form['usermail'] = [
+            '#type' => 'email',
+            '#title' => 'Email',
+            '#required' => true,
+        ];
+        $form['usergender'] = [
+            '#type' => 'select',
+            '#title' => 'Gender',
+            '#options' => [
+                'male' => 'Male',
+                'female' => 'Female',
+                'other' => 'Other'
+            ],
+        ];
+        $form['submit'] = [
+            '#type' => 'submit',
+            '#value' => 'Submit',
+        ];
+        return $form;
+    }
+
+    /**
+     * Defining the validateForm() method
+     * Enforcing the rules for the username length
+     */
+    public function validateForm(array &$form, FormStateInterface $form_state) {
+        // Enforcing the username length to be more than 6 characters
+        if (strlen($form_state->getValue('username')) < 7) {
+            $form_state->setErrorByname('username', "please make sure your username length is more than 6 characters");
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     * Enforcing the submitForm() method
+     **/
+    public function submitForm(array &$form, FormStateInterface $form_state) {
+        \Drupal::messenger()->addMessage("User Details Submitted Successfully");
+    }
+}

--- a/modules/custom/custom_form/src/Form/CustomUserDetails.php
+++ b/modules/custom/custom_form/src/Form/CustomUserDetails.php
@@ -18,7 +18,7 @@ class CustomUserDetails extends FormBase {
      * Defining the buildForm() method
      **/
     public function buildForm(array $form, FormStateInterface $form_state) {
-        // Adding the customjsform library to be only applied to this form.
+        // Adding the customjsform library to be only applied to this form
         $form['#attached']['library'][] = "custom_form/customjsform";
         $form['username'] = [
             '#type' => 'textfield',


### PR DESCRIPTION
Scenario: We need to have a custom form, and need to set the conditions on the length of characters on the 'username' field in the form & need to store the user details in the database when the user details are submitted. 

- We need to add the custom library and it needs to be applied to only this specific form
- Adding the role_based permissions for the path defined in the routing.yml file

To solve the above scenario, we have added the following stuff:
- Created 'custom_form' custom module 
- Added the routing file for path '\get-user-details' and defined the 'CustomUserDetails.php' file
- Defined the CustomUser Details class with the business logic & enforced the length of characters in the 'username' field in the form
- Creating the 'custom_form.schema' file and defining the schema details of the user information to store in the database
- Added 'custom_form.libraries.yml' file & then attached this library to the buildForm() method so that it can be applied only to this form
- Added role_based_permissions code in routing.yml file