### PR TITLE
OP-47b: Adding the Ajax functionality for custom_form

### DIFF
--- a/modules/custom/custom_form/custom_form.routing.yml
+++ b/modules/custom/custom_form/custom_form.routing.yml
@@ -11,3 +11,10 @@ custom-user-form:
     # below line will give access only to authenticated & content_editor. It doesn't give the access for
     # administrator
     # _role: 'authenticated + content_editor'
+custom-modal-page:
+  path: '/modal-form-link'
+  defaults:
+    _controller: '\Drupal\custom_form\Controller\CustomController::modalLink'
+    _title: 'Open Modal Page'
+  requirements:
+    _permission: 'access content'

--- a/modules/custom/custom_form/js/customform.js
+++ b/modules/custom/custom_form/js/customform.js
@@ -1,0 +1,8 @@
+(function ($, Drupal) {
+
+    $.fn.datacheck = function() {
+        alert("hello");
+        $("#custom-user-details-form").submit();
+    };
+
+}(jQuery, Drupal));

--- a/modules/custom/custom_form/src/Controller/CustomController.php
+++ b/modules/custom/custom_form/src/Controller/CustomController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\custom_form\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+class CustomController extends ControllerBase {
+
+    public function modalLink() {
+        $build['#attached']['library'][] = 'core/drupal.dialog.ajax';
+        $build = [
+            '#markup' => '<a href="/localpath/get-user-details" class="use-ajax" data-dialog-type="modal">Click here</a>',
+        ];
+        return $build;
+    }
+
+}

--- a/modules/custom/custom_form/src/Form/CustomUserDetails.php
+++ b/modules/custom/custom_form/src/Form/CustomUserDetails.php
@@ -44,6 +44,9 @@ class CustomUserDetails extends FormBase {
         $form['submit'] = [
             '#type' => 'submit',
             '#value' => 'Submit',
+            '#ajax' => [
+               'callback' => '::setAjaxSubmit',
+            ],
         ];
         return $form;
     }

--- a/modules/custom/custom_form/src/Form/CustomUserDetails.php
+++ b/modules/custom/custom_form/src/Form/CustomUserDetails.php
@@ -4,6 +4,8 @@ namespace Drupal\custom_form\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\InvokeCommand;
 
 class CustomUserDetails extends FormBase {
     /**
@@ -45,6 +47,12 @@ class CustomUserDetails extends FormBase {
         ];
         return $form;
     }
+
+     public function setAjaxSubmit() {
+            $response = new AjaxResponse();
+            $response->addCommand(new InvokeCommand("html", 'datacheck'));
+            return $response;
+     }
 
     /**
      * Defining the validateForm() method


### PR DESCRIPTION
**Scenario**: When the 'custom_form' has been submitted we need to invoke the jQuery method & also the Ajax functionality.

- We also need to show the User details of the submitted form in the modal-popup after it's been submitted.

We have solved the above scenario by adding the following stuff:

- Adding the new modal-popup page path in the routing file & defining the Controller file
- Adding the Ajax functionality in the buildForm() method, submit render array
- Adding the Ajaxsetup method in the Form class
- Adding the customform js file & writing the business logic for js over there.
- This PR has dependency on https://github.com/prudhviphp1/d10-cookbook/pull/76, , https://github.com/prudhviphp1/d10-cookbook/pull/77