### PR TITLE
OP-49: Adding the custom_field_type

### DIFF
--- a/modules/custom/custom_field_type/custom_field_type.info.yml
+++ b/modules/custom/custom_field_type/custom_field_type.info.yml
@@ -1,0 +1,5 @@
+name: custom field type
+# Creating the custom field type where we need to create the field_type, field_widget & field_formatter plugins
+description: creating the custom field type
+type: module
+core_version_requirement: ^9 || ^10

--- a/modules/custom/custom_field_type/src/Plugin/Field/FieldFormatter/CustomFieldFormatter.php
+++ b/modules/custom/custom_field_type/src/Plugin/Field/FieldFormatter/CustomFieldFormatter.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\custom_field_type\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+
+/**
+ * Define the "custom field formatter".
+ * As per the Drupal Community Guidelines, we need to specify the annotation for all
+ * the plugin types
+ *
+ * @FieldFormatter(
+ *   id = "custom_field_formatter",
+ *   label = @Translation("Custom Field Formatter"),
+ *   description = @Translation("Description for Custom Field Formatter"),
+ *   field_types = {
+ *     "custom_field_type"
+ *   }
+ * )
+ */
+
+
+class CustomFieldFormatter extends FormatterBase {
+
+    /**
+     * {@inheritdoc}
+     * Defining defaultSettings() method
+     */
+    public static function defaultSettings() {
+        return [
+            'concat' => 'Concat with ',
+        ] + parent::defaultSettings();
+    }
+
+    /**
+     * {@inheritdoc}
+     * Defining settingsForm() method
+     */
+
+    public function settingsForm(array $form, FormStateInterface $form_state) {
+        $form['concat'] =[
+            '#type' => 'textfield',
+            '#title' => 'Concatenate with',
+            '#default_value' => $this->getSetting('concat'),
+        ];
+        return $form;
+    }
+
+    /**
+     * {@inheritdoc}
+     * Defining settingsSummary() method
+     */
+    public function settingsSummary() {
+        $summary = [];
+        $summary[] = $this->t("concatenate with : @concat", ["@concat" => $this->getSetting('concat')]);
+        return $summary;
+    }
+
+    /**
+     * {@inheritdoc}
+     * Defining viewElements() method
+     */
+
+     public function viewElements(FieldItemListInterface $items, $langcode) {
+        $element = [];
+
+        foreach ( $items as $delta => $item) {
+            $element[$delta] = [
+                '#markup' => $this->getSetting('concat') . $item->value,
+            ];
+        }
+        return $element;
+     }
+
+}

--- a/modules/custom/custom_field_type/src/Plugin/Field/FieldType/CustomFieldType.php
+++ b/modules/custom/custom_field_type/src/Plugin/Field/FieldType/CustomFieldType.php
@@ -17,6 +17,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   label = @Translation("Custom Field Type"),
  *   description = @Translation("Description for Custom Field Type"),
  *   category = @Translation("Text"),
+ *   default_widget = "custom_field_widget", (Adding the field_widget after the field_widget class has been created)
  * )
  */
 

--- a/modules/custom/custom_field_type/src/Plugin/Field/FieldType/CustomFieldType.php
+++ b/modules/custom/custom_field_type/src/Plugin/Field/FieldType/CustomFieldType.php
@@ -9,6 +9,8 @@ use Drupal\Core\TypedData\DataDefinition;
 
 /**
  * Define the "custom field type".
+ * As per the Drupal Community Guidelines, we need to specify the annotation for all
+ * the plugin types
  *
  * @FieldType(
  *   id = "custom_field_type",

--- a/modules/custom/custom_field_type/src/Plugin/Field/FieldType/CustomFieldType.php
+++ b/modules/custom/custom_field_type/src/Plugin/Field/FieldType/CustomFieldType.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\custom_field_type\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Define the "custom field type".
+ *
+ * @FieldType(
+ *   id = "custom_field_type",
+ *   label = @Translation("Custom Field Type"),
+ *   description = @Translation("Description for Custom Field Type"),
+ *   category = @Translation("Text"),
+ * )
+ */
+
+class CustomFieldType extends FieldItemBase {
+
+    /**
+     * {@inheritdoc}
+     */
+
+    public static function schema(FieldStorageDefinitionInterface $field_definition) {
+        return [
+            'columns' => [
+                'value' => [
+                    'type' => 'varchar',
+                    'length' => $field_definition->getSetting("length"),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function defaultStorageSettings() {
+        return [
+            'length' => 255,
+        ] + parent::defaultStorageSettings();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function storageSettingsForm(array &$form, FormStateInterface $form_state, $has_data) {
+        $element = [];
+
+        $element['length'] = [
+            '#type' => 'number',
+            '#title' => t("Length of your text"),
+            '#required' => TRUE,
+            '#default_value' => $this->getSetting("length"),
+        ];
+        return $element;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function defaultFieldSettings() {
+        return [
+            'moreinfo' => "More info default value",
+        ] + parent::defaultFieldSettings();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fieldSettingsForm(array $form, FormStateInterface $form_state) {
+        $element = [];
+        $element['moreinfo'] = [
+            '#type' => 'textfield',
+            '#title' => 'More information about this field',
+            '#required' => TRUE,
+            '#default_value' => $this->getSetting("moreinfo"),
+        ];
+        return $element;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function PropertyDefinitions(FieldStorageDefinitionInterface $field_definition) {
+        $properties['value'] = DataDefinition::create('string')->setLabel(t("Name"));
+
+        return $properties;
+    }
+}

--- a/modules/custom/custom_field_type/src/Plugin/Field/FieldType/CustomFieldType.php
+++ b/modules/custom/custom_field_type/src/Plugin/Field/FieldType/CustomFieldType.php
@@ -18,6 +18,7 @@ use Drupal\Core\TypedData\DataDefinition;
  *   description = @Translation("Description for Custom Field Type"),
  *   category = @Translation("Text"),
  *   default_widget = "custom_field_widget", (Adding the field_widget after the field_widget class has been created)
+ *   default_formatter = "custom_field_formatter", (Adding the field_formatter after the field_formatter class has been created)
  * )
  */
 

--- a/modules/custom/custom_field_type/src/Plugin/Field/FieldWidget/CustomFieldWidget.php
+++ b/modules/custom/custom_field_type/src/Plugin/Field/FieldWidget/CustomFieldWidget.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\custom_field_type\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Defining the "custom field widget".
+ * As per the Drupal Community Guidelines, we need to specify the annotation for all
+ * the plugin types
+ *
+ * @FieldWidget(
+ *   id = "custom_field_widget",
+ *   label = @Translation("Custom Field Widget"),
+ *   description = @Translation("Description for Custom Field Widget"),
+ *   field_types = {
+ *     "custom_field_type"
+ *   }
+ * )
+ */
+
+class CustomFieldWidget extends WidgetBase {
+
+    /**
+     * {@inheritdoc}
+     * Defining formElement() method
+     */
+
+     public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+        $value = isset($items[$delta]->value) ? $items[$delta]->value : "";
+        $element = $element + [
+            '#type' => 'textfield',
+            '#suffix' => "<span>" . $this->getFieldSetting("moreinfo") . "</span>",
+            '#default_value' => $value,
+            '#attributes' => [
+                'placeholder' => $this->getSetting('placeholder'),
+            ],
+        ];
+        return ['value' => $element];
+     }
+
+     /**
+      * {@inheritdoc}
+      * Defining defaultSettings() method
+      */
+      public static function defaultSettings() {
+        return [
+            'placeholder' => 'default',
+        ] + parent::defaultSettings();
+      }
+
+      /**
+       * {@inheritdoc}
+       * Defining settingsForm() method and defining the 'placeholder' value here
+       */
+      public function settingsForm(array $form, FormStateInterface $form_state) {
+        $element['placeholder'] = [
+            '#type' => 'textfield',
+            '#title' => 'Placeholder Text',
+            '#default_value' => $this->getSetting('placeholder'),
+        ];
+        return $element;
+      }
+
+      /**
+       * {@inheritdoc}
+       * Defining the settingsSummary() method so that it can show the summary with below business logic by grabbing
+       * the 'placeholder' value from the above method
+       */
+      public function settingsSummary() {
+        $summary = [];
+        $summary[] = $this->t("placeholder Text: @placeholder", array("@placeholder" => $this->getSetting("placeholder")));
+        return $summary;
+      }
+
+
+}


### PR DESCRIPTION
Scenario: Need to create a new Field type programmatically in the 'Article' content type(CT)

We have solved the above scenario by adding the following steps:

- Created 'custom_field_type' custom module
- Created a new CustomFieldType file with the custom features
- Created a new CustomFieldWidget file with the custom features
- Created a new CustomFieldFormatter file with the custom features